### PR TITLE
Sort glyphnames 

### DIFF
--- a/AdjustAnchors.roboFontExt/lib/AdjustAnchors.py
+++ b/AdjustAnchors.roboFontExt/lib/AdjustAnchors.py
@@ -595,7 +595,7 @@ class AdjustAnchors(BaseWindowController):
 					for glyphName in glyphNamesList[::-1]: # iterate from the end of the list
 						if glyphName in self.marksDict:
 							glyphNamesList.remove(glyphName)
-
+		glyphNamesList.sort()
 		return glyphNamesList
 
 


### PR DESCRIPTION
This sorts the glyphnames so that the order of the presented glyphs will be the same. This is helpful when reviewing multiple fonts and switching between them. 