### PR TITLE
Need `shortKey` in plist

### DIFF
--- a/AdjustAnchors.roboFontExt/info.plist
+++ b/AdjustAnchors.roboFontExt/info.plist
@@ -9,6 +9,8 @@
 			<string>AdjustAnchors.py</string>
 			<key>preferredName</key>
 			<string>Adjust Anchors</string>
+			<key>shortKey</key>
+			<string></string>
 		</dict>
 	</array>
 	<key>developer</key>


### PR DESCRIPTION
See http://robofont.com/documentation/building-tools/extensions/extension-file-spec/#menu-item-description. Without this, Mechanic will choke.